### PR TITLE
Switching to old style support for multiple types for type hints to s…

### DIFF
--- a/light_s3_client/__init__.py
+++ b/light_s3_client/__init__.py
@@ -7,10 +7,11 @@ import io
 import xmltodict
 import os
 import logging
+from typing import Union
 
 
 __author__ = 'socket.dev'
-__version__ = '0.0.16'
+__version__ = '0.0.19'
 __all__ = [
     "Client",
 ]
@@ -175,7 +176,7 @@ class Client:
 
     def upload_fileobj(
         self,
-        Fileobj: bytes | io.TextIOWrapper | io.BufferedReader,
+        Fileobj: Union[bytes, io.TextIOWrapper, io.BufferedReader],
         Bucket: str,
         Key: str
     ) -> [requests.Response, None]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 
 name = light-s3-client
-version = 0.0.18
+version = 0.0.19
 author = Douglas Coburn
 author_email = douglas@dactbc.com
 description = A lightweight S3 client that does not rely on boto3


### PR DESCRIPTION
Lambda functions don't seem to be on a new enough version of Python to support doing type hints in the fashion of `var: Type1 | Type2` switching to Union.