### PR TITLE
Loosen up required requests version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.8"
 license = "MIT"
 license-files = ["LICENSE"]
 dependencies = [
-	"requests~=2.31.0",
+	"requests>=2.31,<3",
 	"xmltodict~=0.13.0"
 ]
 keywords = ["s3", "aws", "client", "lightweight"]

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "python-dotenv", marker = "extra == 'dev'" },
-    { name = "requests", specifier = "~=2.31.0" },
+    { name = "requests", specifier = ">=2.31,<3" },
     { name = "xmltodict", specifier = "~=0.13.0" },
 ]
 provides-extras = ["dev", "test"]


### PR DESCRIPTION
Requests were pinned to 2.31 which is too strict.